### PR TITLE
Fix for issue 1 - Endpoints that vary only by wildcard presence break each other

### DIFF
--- a/projects/ngx-mastermock/package.json
+++ b/projects/ngx-mastermock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mastermock",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/lbdorrou/ngx-mastermock"

--- a/projects/ngx-mastermock/src/lib/mock-environment.service.ts
+++ b/projects/ngx-mastermock/src/lib/mock-environment.service.ts
@@ -80,9 +80,9 @@ export class MockEnvironment {
             }
 
             if (validUrls.length > 1) {
-                const requestedPath = new URL(trimmedUrl).pathname.split('/').filter(e => e);
+                const requestedPath = this.getUrlPath(trimmedUrl).split('/');
                 validUrls.forEach(validUrl => {
-                    const testPath = new URL(validUrl.matchedUrl).pathname.split('/').filter(e => e);
+                    const testPath = this.getUrlPath(validUrl.matchedUrl).split('\\/');
                     if (this.pathsAreEqual(requestedPath, testPath)) {
                         contextUrl = validUrl.urlMap;
                         wildcards = validUrl.wildcards;
@@ -111,13 +111,17 @@ export class MockEnvironment {
         return contextUrl.endpoint.call(contextUrl.parent, request, wildcards, urlParams);
     }
 
+    getUrlPath(url: string) {
+        return url.match(/^(?:[^\/]*(?:\/(?:\/[^\/]*\/?)?)?([^?]+)(?:\??.+)?)$/)[1];
+    }
+
     pathsAreEqual(requestedPath: Array<string>, testPath: Array<string>) {
         if (!Array.isArray(requestedPath) || !Array.isArray(testPath) || requestedPath.length !== testPath.length) {
             return false;
         }
 
         for (let i = 0; i < requestedPath.length; i++) {
-            if (testPath[i].includes('([a-zA-Z0-9$-_.+!*(),%20]+)')) {
+            if (testPath[i].includes('([a-zA-Z0-9$-_.+!*(), ]+')) {
                 continue;
             } else if (requestedPath[i] !== testPath[i]) {
                 return false;


### PR DESCRIPTION
[Fix for issue 1 - Endpoints that vary only by wildcard presence break each other.](https://github.com/lbdorrou/ngx-mastermock/issues/1)

Tested locally in wrapper project with following and WAI
~~~
public registerEndpoints() {
    return {
        'https://example.com/path/to/shipments/${orderNumber}': this.shipmentPage,
        'https://example.com/path/to/shipments/detail/${orderNumber}': this.shipmentDetailsPage,
        'https://example.com/path/to/nothing/${orderNumber}': this.notFound,
        'https://example.com/part1/${wildcard1}/part2/${wildcard2}/part3': this.shipmentDetailsPage,
        'https://example.com/part1/part2/${wildcard2}/part3': this.shipmentPage
    };
}
~~~

Also, tested using local build of Shipper. http://localhost:4200/shipments/fms/1111 - would use wrong mock and not work; page uses correct mock now. Existing pages also maintain functionality from my testing